### PR TITLE
Fixes tessel/runtime#193

### DIFF
--- a/serialize.js
+++ b/serialize.js
@@ -127,7 +127,7 @@ function rerez($, $$)
         return item.substr(2);
       case 'b':
         var bounds = item.substr(2).split(',', 2);
-        return $$.slice(bounds[0] || 0, (bounds[0] || 0) + (bounds[1] || [0]));
+        return $$.slice(parseInt(bounds[0]) || 0, (parseInt(bounds[0]) || 0) + (parseInt(bounds[1]) || [0]));
       case 'd':
         return new Date(item.substr(2));
       case 'r':

--- a/test/test.js
+++ b/test/test.js
@@ -98,3 +98,30 @@ test('errors', function (t) {
   t.ok(err instanceof Error);
   t.ok(err.message == 'boo!');
 });
+
+test('arrays of buffers', function(t) {
+  t.plan(5);
+
+  var b1 = new Buffer([0, 1, 2, 3, 4, 5]);
+  var b2 = new Buffer([6, 7, 8, 9, 10, 11]);
+  var arr = [b1, b2];
+
+  var clone = require('../');
+
+  var buf = clone.deserialize(clone.serialize(arr));
+
+  t.ok(buf.length === arr.length);
+  t.ok(buf[0].length === arr[0].length);
+  t.ok(buf[1].length === arr[0].length);
+
+  function bufferEqual (a, b) {
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+
+  t.ok(bufferEqual(buf[0], arr[0]));
+  t.ok(bufferEqual(buf[1], arr[1]));
+
+})


### PR DESCRIPTION
Fixes a bug where buffer bounds were being parsed as strings instead of numbers leading to results like: `6 + 6 = 66`. This is not good for Buffer indexes.
